### PR TITLE
:sparkles: add toggle for dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,10 @@
 {
   "author": "Venu Madhav",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "http-tracker@github.com"
+    }
+  },
   "background":
   {
     "scripts": [

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,3 +1,32 @@
+html.dark-mode body {
+  color: #bbb;
+  background-color: #111;
+}
+
+html.dark-mode input,
+html.dark-mode select,
+html.dark-mode textarea {
+  color: #efefef;
+  background-color: #050505;
+  border: 1px solid #888;
+}
+
+html.dark-mode button {
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+html.dark-mode .urls_list_heading {
+  background-color: #181818;
+}
+
+input {
+  border: 1px solid #111;
+  border-radius: 2px;
+}
+
 .web_event_tracker {
   margin: 2% 2% 2% 2%;
   height: 100%;
@@ -83,6 +112,10 @@ input {
   background-color: #DCDCDC;
 }
 
+html.dark-mode .web_event_list_blank:hover {
+  background-color: #444;
+}
+
 .web_event_list_style:first-child {
   border-top: none;
 }
@@ -107,6 +140,10 @@ input {
 
 .web_event_list_selected {
   background-color: #CBE4EC;
+}
+
+html.dark-mode .web_event_list_selected {
+  background-color: #333;
 }
 
 .web_event_list_container {
@@ -160,12 +197,20 @@ input {
   border-color: black;
 }
 
+html.dark-mode .web_event_list_url {
+  border-color: #181818;
+}
+
 .web_event_list_method {
   float: left;
   width: 5%;
   text-align: center;
   border-right: 1px solid;
   border-color: black;
+}
+
+html.dark-mode .web_event_list_method {
+  border-color: #181818;
 }
 
 .web_event_list_status {
@@ -176,12 +221,20 @@ input {
   border-color: black;
 }
 
+html.dark-mode .web_event_list_status {
+  border-color: #181818;
+}
+
 .web_event_list_date_time {
   float: left;
   width: 15%;
   text-align: center;
   border-right: 1px solid;
   border-color: black;
+}
+
+html.dark-mode .web_event_list_time {
+  border-color: #181818;
 }
 
 .web_event_list_cache {
@@ -203,6 +256,10 @@ input {
   text-align: center;
   background-color: cadetblue;
   border: 1px solid;
+}
+
+html.dark-mode .web_event_detail_cookie {
+  background-color: #225;
 }
 
 .web_event_detail_td {
@@ -228,12 +285,21 @@ input {
   width: 50%;
 }
 
+html.dark-mode .web_event_detail_request_heading {
+  background: #333;
+}
+
+
 .web_event_detail_response_heading {
   text-align: center;
   background: #DCDCDC;
   border-top: 1px solid;
   border-right: 1px solid;
   border-bottom: 1px solid;
+}
+
+html.dark-mode .web_event_detail_response_heading {
+  background: #333;
 }
 
 .web_event_response_header_details {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -6,7 +6,7 @@ html.dark-mode body {
 html.dark-mode input,
 html.dark-mode select,
 html.dark-mode textarea {
-  color: #efefef;
+  color: #eee;
   background-color: #050505;
   border: 1px solid #888;
 }

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -16,6 +16,15 @@
         <input type="radio" name="uipage" value="false" id="popup">popup
       </label>
     </div>
+    <div style="float: left; width: 30%; height:50px;">Dark mode (change takes effect on restart of addon window)</div>
+    <div style="height: 50px">
+      <label style="padding-left: 20px;">
+        <input type="radio" name="uidark" value="true" id="dark_mode_enabled">enabled
+      </label>
+      <label style="padding-left: 20px;">
+        <input type="radio" name="uidark" value="false" id="dark_mode_disabled">disabled
+      </label>
+    </div>
     <div style="float:left; width:30%;">
       Include URL patterns
     </div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -3,6 +3,16 @@
 
 <head>
   <meta charset="utf-8" />
+  <style type="text/css">
+    html.dark-mode {
+      color: #bbb;
+      background-color: #111;
+    }
+    html.dark-mode textarea {
+      background-color: #050505;
+      color: #eee;
+    }
+  </style>
 </head>
 
 <body>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -35,6 +35,15 @@
         <input type="radio" name="uidark" value="false" id="dark_mode_disabled">disabled
       </label>
     </div>
+    <div style="float: left; width: 30%; height:50px;">Event order (change takes effect on restart of addon window)</div>
+    <div style="height: 50px">
+      <label style="padding-left: 20px;">
+        <input type="radio" name="reverse_list" value="false" id="reverse_list_disabled">Chronological (latest at the bottom)
+      </label>
+      <label style="padding-left: 20px;">
+        <input type="radio" name="reverse_list" value="true" id="reverse_list_enabled">Reverse-chronological (latest at the top)
+      </label>
+    </div>
     <div style="float:left; width:30%;">
       Include URL patterns
     </div>

--- a/src/js/httpTrackerConstants.js
+++ b/src/js/httpTrackerConstants.js
@@ -6,8 +6,18 @@ const httpTracker = {
   STORAGE_KEY_INCLUDE_PATTERN: "httpTracker_GlobalIncludePatterns",
   STORAGE_KEY_BLOCK_PATTERN: "httpTracker_GlobalBlockPatterns",
   STORAGE_KEY_MASK_PATTERN: "httpTracker_GlobalMaskPatterns",
-  STORAGE_KEY_OPEN_ADDON_IN_TAB: "httpTracker_OpenAddonInTab"
+  STORAGE_KEY_OPEN_ADDON_IN_TAB: "httpTracker_OpenAddonInTab",
+  STORAGE_KEY_DARK_MODE_ENABLED: "httpTracker_DarkModeEnabled"
 };
+
+httpTracker.allStorageKeys = [
+  httpTracker.STORAGE_KEY_EXCLUDE_PATTERN,
+  httpTracker.STORAGE_KEY_INCLUDE_PATTERN,
+  httpTracker.STORAGE_KEY_BLOCK_PATTERN,
+  httpTracker.STORAGE_KEY_MASK_PATTERN,
+  httpTracker.STORAGE_KEY_OPEN_ADDON_IN_TAB,
+  httpTracker.STORAGE_KEY_DARK_MODE_ENABLED,
+];
 
 const FORBIDDEN_HEADERS = ["Accept-Charset", "Accept-Encoding", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Connection", "Content-Length", "Cookie", "Cookie2", "Date", "DNT", "Expect", "Feature-Policy", "Host", "Keep-Alive", "Origin", "Proxy-", "Sec-", "Referer", "TE", "Trailer", "Transfer-Encoding", "Upgrade", "Via"];
 const FORBIDDEN_HEADERS_PATTERN = ["Proxy-", "Sec-"];

--- a/src/js/httpTrackerConstants.js
+++ b/src/js/httpTrackerConstants.js
@@ -7,7 +7,8 @@ const httpTracker = {
   STORAGE_KEY_BLOCK_PATTERN: "httpTracker_GlobalBlockPatterns",
   STORAGE_KEY_MASK_PATTERN: "httpTracker_GlobalMaskPatterns",
   STORAGE_KEY_OPEN_ADDON_IN_TAB: "httpTracker_OpenAddonInTab",
-  STORAGE_KEY_DARK_MODE_ENABLED: "httpTracker_DarkModeEnabled"
+  STORAGE_KEY_DARK_MODE_ENABLED: "httpTracker_DarkModeEnabled",
+  STORAGE_KEY_REVERSE_LIST: "httpTracker_ReverseList"
 };
 
 httpTracker.allStorageKeys = [
@@ -17,6 +18,7 @@ httpTracker.allStorageKeys = [
   httpTracker.STORAGE_KEY_MASK_PATTERN,
   httpTracker.STORAGE_KEY_OPEN_ADDON_IN_TAB,
   httpTracker.STORAGE_KEY_DARK_MODE_ENABLED,
+  httpTracker.STORAGE_KEY_REVERSE_LIST,
 ];
 
 const FORBIDDEN_HEADERS = ["Accept-Charset", "Accept-Encoding", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Connection", "Content-Length", "Cookie", "Cookie2", "Date", "DNT", "Expect", "Feature-Policy", "Host", "Keep-Alive", "Origin", "Proxy-", "Sec-", "Referer", "TE", "Trailer", "Transfer-Encoding", "Upgrade", "Via"];

--- a/src/js/httpTrackerOptions.js
+++ b/src/js/httpTrackerOptions.js
@@ -9,19 +9,29 @@ const idToKeyLookup = {
   "default_mask_patterns": httpTracker.STORAGE_KEY_MASK_PATTERN,
   "dark_mode_enabled": httpTracker.STORAGE_KEY_DARK_MODE_ENABLED,
   "dark_mode_disabled": httpTracker.STORAGE_KEY_DARK_MODE_ENABLED,
+  "reverse_list_enabled": httpTracker.STORAGE_KEY_REVERSE_LIST,
+  "reverse_list_disabled": httpTracker.STORAGE_KEY_REVERSE_LIST
 };
 
 const toggles = new Set([
   "tab",
   "popup",
   "dark_mode_enabled",
-  "dark_mode_disabled"
+  "dark_mode_disabled",
+  "reverse_list_disabled",
+  "reverse_list_enabled"
 ]);
 
 // Whenever the contents of the text area is changed and then loses focus, save the new values
 async function storeSettings(event) {
   let id = event.target.id;
   let value = uniqueArray(stringToArray(event.target.value, /\n|\t|\ |\,/));
+  console.log({
+    id,
+    value,
+    toggles: Array.from(toggles),
+    idToKeyLookup
+  });
   const key = idToKeyLookup[id];
   if (!key) {
     console.error(`No id to preference key lookup for id '${id}'`);
@@ -63,6 +73,13 @@ httpTracker.browser.storage.sync.get(httpTracker.allStorageKeys, function (cbRes
   if (!!value) {
     document.documentElement.classList.add("dark-mode");
   }
+
+  value = getPropertyFromStorage(cbResponseParams, httpTracker.STORAGE_KEY_REVERSE_LIST);
+  if (value === undefined) {
+    setPropertyToStorage(httpTracker.STORAGE_KEY_REVERSE_LIST, false);
+  }
+  getById("reverse_list_enabled").checked = !!value;
+  getById("reverse_list_disabled").checked = !value;
 });
 
 document.querySelector("#dark_mode_disabled").addEventListener("change", () => {

--- a/src/js/httpTrackerOptions.js
+++ b/src/js/httpTrackerOptions.js
@@ -59,7 +59,18 @@ httpTracker.browser.storage.sync.get(httpTracker.allStorageKeys, function (cbRes
   }
   getById("dark_mode_enabled").checked = !!value;
   getById("dark_mode_disabled").checked = !value;
+
+  if (!!value) {
+    document.documentElement.classList.add("dark-mode");
+  }
 });
+
+document.querySelector("#dark_mode_disabled").addEventListener("change", () => {
+  document.documentElement.classList.remove("dark-mode");
+})
+document.querySelector("#dark_mode_enabled").addEventListener("change", () => {
+  document.documentElement.classList.add("dark-mode");
+})
 
 function getProcessedValue(value) {
   if (value && value.length) {

--- a/src/js/httpTrackerProcessor.js
+++ b/src/js/httpTrackerProcessor.js
@@ -1069,7 +1069,7 @@ let eventTracker = (function() {
     globalIncludeURLsList = getPropertyFromStorage(details, httpTracker.STORAGE_KEY_INCLUDE_PATTERN);
   }
 
-  function getChangesFromStorge(changes, namespace) {
+  function getChangesFromStorage(changes, namespace) {
     for (var key in changes) {
       if (key === httpTracker.STORAGE_KEY_EXCLUDE_PATTERN) {
         globalExcludeURLsList = changes[key].newValue;
@@ -1083,7 +1083,7 @@ let eventTracker = (function() {
     displayEventProperties();
   }
 
-  httpTracker.browser.storage.onChanged.addListener(getChangesFromStorge);
+  httpTracker.browser.storage.onChanged.addListener(getChangesFromStorage);
   httpTracker.browser.storage.sync.get([httpTracker.STORAGE_KEY_INCLUDE_PATTERN, httpTracker.STORAGE_KEY_EXCLUDE_PATTERN, httpTracker.STORAGE_KEY_MASK_PATTERN], getGlobalOptions);
 
   return {

--- a/src/js/httpTrackerProcessor.js
+++ b/src/js/httpTrackerProcessor.js
@@ -14,6 +14,7 @@ let eventTracker = (function() {
   let filterWithValueTimeout = null;
   let globalExcludeURLsList;
   let globalIncludeURLsList;
+  let globalReverseURLsList = false;
   let globalMaskPatternsList;
   let maskAttributesCheckboxValue = false;
   let maskedAttributesList;
@@ -214,7 +215,9 @@ let eventTracker = (function() {
       generateDATETIMEContent(webEvent) +
       generateCACHEContent(webEvent) +
       "</div>";
-    getById("urls_list").insertAdjacentHTML("beforeend", containerContent);
+    const position = globalReverseURLsList ? "afterbegin" : "beforeend";
+    console.log("insert event", position);
+    getById("urls_list").insertAdjacentHTML(position, containerContent);
   }
 
   function updateEventList(webEvent) {
@@ -1067,6 +1070,7 @@ let eventTracker = (function() {
     globalExcludeURLsList = getPropertyFromStorage(details, httpTracker.STORAGE_KEY_EXCLUDE_PATTERN);
     globalMaskPatternsList = getPropertyFromStorage(details, httpTracker.STORAGE_KEY_MASK_PATTERN);
     globalIncludeURLsList = getPropertyFromStorage(details, httpTracker.STORAGE_KEY_INCLUDE_PATTERN);
+    globalReverseURLsList = getPropertyFromStorage(details, httpTracker.STORAGE_KEY_REVERSE_LIST);
   }
 
   function getChangesFromStorage(changes, namespace) {
@@ -1084,7 +1088,12 @@ let eventTracker = (function() {
   }
 
   httpTracker.browser.storage.onChanged.addListener(getChangesFromStorage);
-  httpTracker.browser.storage.sync.get([httpTracker.STORAGE_KEY_INCLUDE_PATTERN, httpTracker.STORAGE_KEY_EXCLUDE_PATTERN, httpTracker.STORAGE_KEY_MASK_PATTERN], getGlobalOptions);
+  httpTracker.browser.storage.sync.get([
+    httpTracker.STORAGE_KEY_INCLUDE_PATTERN,
+    httpTracker.STORAGE_KEY_EXCLUDE_PATTERN,
+    httpTracker.STORAGE_KEY_MASK_PATTERN,
+    httpTracker.STORAGE_KEY_REVERSE_LIST
+  ], getGlobalOptions);
 
   return {
     logRequestDetails: logRequestDetails

--- a/src/js/httpTrackerUtils.js
+++ b/src/js/httpTrackerUtils.js
@@ -157,6 +157,19 @@ function addModifyRequestHeaders(webEvent) {
   return webEvent.requestHeaders;
 }
 
+function setupDarkMode() {
+  httpTracker.browser.storage.sync.get([httpTracker.STORAGE_KEY_DARK_MODE_ENABLED], (data => {
+    const
+      stored = getPropertyFromStorage(data, httpTracker.STORAGE_KEY_DARK_MODE_ENABLED),
+      enabled = stored === "true" || stored === true;
+    if (enabled) {
+      document.documentElement.classList.add("dark-mode");
+    }
+
+  }));
+
+}
+
 function getPropertyFromStorage(details, key) {
   if (httpTracker.browser.runtime.lastError) {
     onError(httpTracker.browser.runtime.lastError);
@@ -175,3 +188,5 @@ function setPropertyToStorage(key, value) {
     // console.log(`Successfully stored ${key} = ${value}`);
   });
 }
+
+window.addEventListener("DOMContentLoaded", setupDarkMode);


### PR DESCRIPTION
- Adds a dark-mode toggle in the options pane 
- honors dark-mode in the main window
- honors dark-mode in the options pane

Note: I had to add the following to the manifest.json so I could debug in firefox:
```json
  "browser_specific_settings": {
    "gecko": {
      "id": "http-tracker@github.com"
    }
  },
```

I'm quite sure you'd have a preference for a better id. Apparently manifest v3 will require the id field.

EDIT: I've also added an option to reverse the order of the list - this means that for someone watching events scrolling through, the latest is always at the top and the user doesn't have to scroll the events list. This is a toggle, defaulted off.